### PR TITLE
Improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Shows some basic information (id, name, etc.) about the user who used this comma
 
 ## Running the bot for testing
 
-To run the bot right from Gradle (just for testing, not for production) you can do `gradlew run -P token=your-bot-token-here`.
+To run the bot right from Gradle (just for testing, not for production) you can do `gradlew run --args your-bot-token-here`.
 You can view the login process by looking at the 
 [Main.java](https://github.com/Javacord/Example-Bot/blob/master/src/main/java/org/javacord/examplebot/Main.java)
 class.

--- a/build.gradle
+++ b/build.gradle
@@ -22,10 +22,3 @@ dependencies {
 }
 
 mainClassName = 'org.javacord.examplebot.Main'
-
-def token = findProperty('token')
-if (token) {
-    run {
-        args token
-    }
-}

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.9-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.9-bin.zip


### PR DESCRIPTION
- Use binary Gradle distribution
- With Gradle 4.9 there is finally a standard way to provide commandline argument to the run task